### PR TITLE
Add llms.txt discoverability via link tag and robots.txt

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -4,7 +4,12 @@ export default function Document() {
   return (
     <Html lang="en">
       <Head>
-        {/* Optionally add hreflang links here for multilingual support */}
+        <link
+          rel="alternate"
+          type="text/plain"
+          href="/llms.txt"
+          title="LLM-readable information"
+        />
       </Head>
       <body>
         <Main />

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,3 +2,4 @@ User-agent: *
 Allow: /
 
 Sitemap: https://madole.xyz/sitemap.xml
+LLMs-txt: https://madole.xyz/llms.txt


### PR DESCRIPTION
## Summary
- Added `<link rel="alternate" type="text/plain" href="/llms.txt">` to `_document.tsx` so every page advertises the llms.txt file in its HTML head
- Added `LLMs-txt:` directive to `robots.txt` alongside the existing sitemap entry

## Test plan
- [ ] Verify the `<link>` tag appears in the `<head>` of rendered pages
- [ ] Verify `robots.txt` includes the new `LLMs-txt` line at `/robots.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced machine-readable resource support to enable better integration with AI systems and tools.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->